### PR TITLE
CTA cancel links and swapped option buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,7 +883,7 @@ padding-left: 16px
   <h3>Initial Presentation</h3>
   <div class="bbcid-actions blq-clearfix">
     <input title="To submit the form, please complete all the fields." class="bbcid-button submit disabled" name="bbcid_submit_button" id="bbcid_submit_button" value="Sign in" type="submit">
-    <a href="#" class="bbcid-button cancel">Cancel</a> 
+    <a href="#cta" class="bbcid-button cancel">Cancel</a> 
   </div>
 
   <div class="bbcid-styleguide-notes">
@@ -922,7 +922,7 @@ padding-left: 10px
   <h3>Active State</h3>
   <div class="bbcid-actions blq-clearfix">
     <input title="To submit the form, please complete all the fields." class="bbcid-button submit" name="bbcid_submit_button" id="bbcid_submit_button" value="Sign in" type="submit">
-    <a href="#" class="bbcid-button cancel">Cancel</a> 
+    <a href="#cta" class="bbcid-button cancel">Cancel</a> 
   </div>
 
   <div class="bbcid-styleguide-notes">
@@ -946,7 +946,7 @@ background-color: #005383
   <p>When the CTA text is too long, the buttons wrap onto 2 lines.</p>
   <div class="bbcid-actions blq-clearfix">
     <input title="To submit the form, please complete all the fields." class="bbcid-button submit" name="bbcid_submit_button" id="bbcid_submit_button" value="This is a long button" type="submit">
-    <a href="#" class="bbcid-button cancel">Long Cancel Text</a> 
+    <a href="#cta" class="bbcid-button cancel">Long Cancel Text</a> 
   </div>
 
 
@@ -989,10 +989,10 @@ background-color: #005383
     <div class="bbcid-radios-container bbcid-isageold-radios-container">
       <div class="bbcid_false_container bbcid_isageold_false_container"> 
         <input class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_false" value="0" type="radio">
-        <a id="bbcid_isageold_false_label_wrapper" href="#"><label for="bbcid_isageold_false" class="bbcid_isageold_false_label inactive">  <span class="bbcid_label_main">Option 1</span></div>
+        <a id="bbcid_isageold_false_label_wrapper" href="#"><label for="bbcid_isageold_false" class="bbcid_isageold_false_label inactive"><span class="bbcid_label_main">Option 1</span></div>
         <div class="bbcid_true_container bbcid_isageold_true_container">
          <input checked="checked" class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_true" value="1" type="radio">
-         <a id="bbcid_isageold_true_label_wrapper" href="#"><label style="padding-left: 33px; padding-right: 10px;" for="bbcid_isageold_true" class="bbcid_isageold_true_label active"><span style="opacity: 1;" class="bbcid-toggle-tick"></span>  <span class="bbcid_label_main">Option 2</span></label></a>   
+         <a id="bbcid_isageold_true_label_wrapper" href="#"><label style="padding-left: 33px; padding-right: 10px;" for="bbcid_isageold_true" class="bbcid_isageold_true_label active"><span style="opacity: 1;" class="bbcid-toggle-tick"></span><span class="bbcid_label_main">Option 2</span></label></a>   
         </div>
      </div>
    </fieldset>
@@ -1007,12 +1007,12 @@ background-color: #005383
     <legend><span class="bbcid_label_main">This is a label</span></legend>
     <div class="bbcid-radios-container bbcid-isageold-radios-container">
       <div class="bbcid_false_container bbcid_isageold_false_container"> 
-          <input class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_false" value="0" type="radio">
-          <a id="bbcid_isageold_false_label_wrapper" href="#"><label for="bbcid_isageold_false" class="bbcid_isageold_false_label inactive">  <span class="bbcid_label_main">Option 1</span>
+          <input checked="checked" class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_false" value="0" type="radio">
+          <a id="bbcid_isageold_false_label_wrapper" href="#"><label style="padding-left: 33px; padding-right: 10px;" for="bbcid_isageold_false" class="bbcid_isageold_false_label active"><span style="opacity: 1;" class="bbcid-toggle-tick"></span><span class="bbcid_label_main">Option 1</span>
       </div>
       <div class="bbcid_true_container bbcid_isageold_true_container">
-           <input checked="checked" class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_true" value="1" type="radio">
-           <a id="bbcid_isageold_true_label_wrapper" href="#"><label style="padding-left: 33px; padding-right: 10px;" for="bbcid_isageold_true" class="bbcid_isageold_true_label active"><span style="opacity: 1;" class="bbcid-toggle-tick"></span>  <span class="bbcid_label_main">Option 2</span></label></a>   
+           <input class="radio" autocomplete="off" name="isageold" id="bbcid_isageold_true" value="1" type="radio">
+           <a id="bbcid_isageold_true_label_wrapper" href="#"><label for="bbcid_isageold_true" class="bbcid_isageold_true_label inactive"><span class="bbcid_label_main">Option 2</span></label></a>   
       </div>
    
      <div class="bbcid-hint-1col">


### PR DESCRIPTION
- Changed CTA Cancel button links to point to the `#cta` section of the page so each time they are clicked they don't redirect to the top of the page.
- Swapped the bottom CTA option buttons to show the selected one with the tick on a different side to the other examples.
